### PR TITLE
docs: fix link to github repo

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -63,4 +63,4 @@ website:
         text: "Reference"
     right:
       - icon: github
-        href: https://github.com/rstudio/shinyswatch
+        href: https://github.com/rstudio/py-shinyswatch


### PR DESCRIPTION
This is a tiny fix, to make it point to the py-shinyswatch repo